### PR TITLE
prevent infinite rerender in starter code

### DIFF
--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -27,7 +27,7 @@ export function Table(): React.ReactElement {
       </Tbody>
       <Tfoot>
         <Tr>
-        <Td colSpan={2}>
+          <Td colSpan={2}>
             <Flex justifyContent="center">
               <InputGroup>
                 <InputLeftElement pointerEvents="none"><SearchIcon /></InputLeftElement>

--- a/src/Users.tsx
+++ b/src/Users.tsx
@@ -25,7 +25,7 @@ function Users() {
       if (data) setUsers(data);
     }
     getUsers();
-  });
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
The `useEffect` hook to fetch data in `Users.tsx` runs after every render since there is no dependency array - and since the hook updates state via `setUsers`, it results in an infinitely rendering loop.  Funnily enough, it doesn't break the app because the effect is async, just makes a bunch of network calls repeatedly.

But if this was included intentionally as a gotcha, feel free to close this PR 🙃 

Also included a fix for a small indentation error.